### PR TITLE
fix: annotation cleanup — @Autowired, interface injection, @Transactional

### DIFF
--- a/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
@@ -5,7 +5,7 @@ import com.foodiesfinds.recipe_service.dto.core.Response;
 import com.foodiesfinds.recipe_service.dto.recipe.RecipeResponseDTO;
 import com.foodiesfinds.recipe_service.dto.recipe.RecipeSaveDTO;
 import com.foodiesfinds.recipe_service.dto.recipe.RecipeUpdateDTO;
-import com.foodiesfinds.recipe_service.service.implementation.RecipeServiceImpl;
+import com.foodiesfinds.recipe_service.service.RecipeService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +20,7 @@ import static org.springframework.http.HttpStatus.OK;
 @RequiredArgsConstructor
 public class RecipeController {
 
-    private final RecipeServiceImpl recipeService;
+    private final RecipeService recipeService;
 
     private final ResponseFactory response;
 

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/CuisineServiceIml.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/CuisineServiceIml.java
@@ -5,13 +5,12 @@ import com.foodiesfinds.recipe_service.core.exception.NotFoundException;
 import com.foodiesfinds.recipe_service.entity.Cuisine;
 import com.foodiesfinds.recipe_service.repository.CuisineRepository;
 import com.foodiesfinds.recipe_service.service.CuisineService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class CuisineServiceIml implements CuisineService {
@@ -19,6 +18,7 @@ public class CuisineServiceIml implements CuisineService {
     private final CuisineRepository cuisineRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Cuisine resolveCuisine(Cuisine requestedCuisine) {
         if (!isCuisineValid(requestedCuisine)) {
             throw new BadRequestException("Cuisine request must have either an ID or a name.");
@@ -36,6 +36,7 @@ public class CuisineServiceIml implements CuisineService {
         return req.getId() != null || (req.getName() != null && !req.getName().isBlank());
     }
 
+    @Transactional
     private Cuisine createNewCuisine(Cuisine cuisine) {
         Cuisine newCuisine = new Cuisine();
         newCuisine.setName(cuisine.getName());

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/IngredientServiceImpl.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/IngredientServiceImpl.java
@@ -7,15 +7,14 @@ import com.foodiesfinds.recipe_service.entity.Ingredient;
 import com.foodiesfinds.recipe_service.mapper.IngredientMapper;
 import com.foodiesfinds.recipe_service.repository.IngredientRepository;
 import com.foodiesfinds.recipe_service.service.IngredientService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
-@Transactional
 public class IngredientServiceImpl implements IngredientService {
 
     private final IngredientMapper ingredientMapper;
@@ -23,11 +22,13 @@ public class IngredientServiceImpl implements IngredientService {
     private final IngredientRepository ingredientRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public IngredientResponseDTO getIngredientById(Long ingredientId) {
         return ingredientMapper.toDTO(ingredientRepository.findById(ingredientId).get());
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Ingredient resolveIngredient(Ingredient requestedIngredient) {
         if (!isIngredientValid(requestedIngredient)) {
             throw new BadRequestException("Ingredient request must have either an ID or a name.");
@@ -45,6 +46,7 @@ public class IngredientServiceImpl implements IngredientService {
         return req.getId() != null || (req.getName() != null && !req.getName().isBlank());
     }
 
+    @Transactional
     private Ingredient createNewIngredient(String name) {
         log.info("Creating new ingredient with name: {}", name);
         Ingredient newIngredient = new Ingredient();

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/RecipeServiceImpl.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/RecipeServiceImpl.java
@@ -15,13 +15,16 @@ import com.foodiesfinds.recipe_service.mapper.RecipeInstructionStepsMapper;
 import com.foodiesfinds.recipe_service.mapper.RecipeMapper;
 import com.foodiesfinds.recipe_service.mapper.RecipeTagMapper;
 import com.foodiesfinds.recipe_service.repository.RecipeRepository;
+import com.foodiesfinds.recipe_service.service.CuisineService;
+import com.foodiesfinds.recipe_service.service.IngredientService;
 import com.foodiesfinds.recipe_service.service.RecipeService;
-import jakarta.transaction.Transactional;
+import com.foodiesfinds.recipe_service.service.TagService;
+import com.foodiesfinds.recipe_service.service.UnitService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collection;
 import java.util.List;
@@ -32,33 +35,17 @@ import java.util.stream.Collectors;
 @Slf4j
 public class RecipeServiceImpl implements RecipeService {
 
-
     private final RecipeRepository recipeRepository;
-
-    @Autowired
-    private final IngredientServiceImpl ingredientService;
-
-    @Autowired
-    private final CuisineServiceIml cuisineService;
-
-    @Autowired
-    private final TagServiceImpl tagService;
-
-    @Autowired
-    private final UnitServiceImpl unitService;
-
-    @Autowired
+    private final IngredientService ingredientService;
+    private final CuisineService cuisineService;
+    private final TagService tagService;
+    private final UnitService unitService;
     private final RecipeMapper recipeMapper;
-
-    @Autowired
     private final RecipeIngredientMapper recipeIngredientMapper;
-
-    @Autowired
     private final RecipeTagMapper recipeTagMapper;
-
-    @Autowired
     private final RecipeInstructionStepsMapper instructionStepMapper;
 
+    @Override
     @Transactional
     public RecipeResponseDTO save(RecipeSaveDTO recipeSaveDTO) {
 
@@ -93,17 +80,17 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public Collection<RecipeResponseDTO> list(int limit) {
         log.info("Fetching the first {} recipes", limit);
         List<Recipe> recipes = recipeRepository.findAll(PageRequest.of(0, limit)).toList();
-        List<RecipeResponseDTO> recipesDTO;
-        recipesDTO = recipes.stream()
+        return recipes.stream()
                 .map(recipeMapper::toDTO)
                 .toList();
-        return recipesDTO.stream().toList();
     }
 
     @Override
+    @Transactional(readOnly = true)
     public RecipeResponseDTO get(Long id) {
         log.info("Fetching recipe by id: {}", id);
         Recipe recipeById = recipeRepository.findById(id)
@@ -188,6 +175,7 @@ public class RecipeServiceImpl implements RecipeService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public List<RecipeResponseDTO> search(String query) {
         List<Recipe> recipes = recipeRepository.findByNameContainingIgnoreCase(query);
         return recipes.stream()

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/TagServiceImpl.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/TagServiceImpl.java
@@ -5,20 +5,20 @@ import com.foodiesfinds.recipe_service.core.exception.NotFoundException;
 import com.foodiesfinds.recipe_service.entity.Tag;
 import com.foodiesfinds.recipe_service.repository.TagRepository;
 import com.foodiesfinds.recipe_service.service.TagService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
-@Transactional
 @Slf4j
 public class TagServiceImpl implements TagService {
 
     private final TagRepository tagRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Tag resolveTag(Tag requestedTag) {
         if (!isTagValid(requestedTag)) {
             throw new BadRequestException("Tag request must have either an ID or a name.");
@@ -35,6 +35,7 @@ public class TagServiceImpl implements TagService {
         return tag != null && (tag.getName() != null || !tag.getName().isEmpty());
     }
 
+    @Transactional
     private Tag createNewTag(Tag tag) {
         Tag newTag = new Tag();
         newTag.setName(tag.getName());

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/UnitServiceImpl.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/UnitServiceImpl.java
@@ -4,18 +4,18 @@ import com.foodiesfinds.recipe_service.core.exception.NotFoundException;
 import com.foodiesfinds.recipe_service.entity.Unit;
 import com.foodiesfinds.recipe_service.repository.UnitRepository;
 import com.foodiesfinds.recipe_service.service.UnitService;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class UnitServiceImpl implements UnitService {
 
     private final UnitRepository unitRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public Unit resolveUnit(Unit unit) {
         return unitRepository.findById(Long.valueOf(unit.getId()))
                 .orElseThrow(() -> new NotFoundException("Unit ID not found: "


### PR DESCRIPTION
## Summary

Fixes all Spring annotation issues identified in code review.

### Changes

**`RecipeController.java`**
- Inject `RecipeService` interface instead of `RecipeServiceImpl`

**`RecipeServiceImpl.java`**
- Remove redundant `@Autowired` on all `final` fields — `@RequiredArgsConstructor` already handles constructor injection
- Inject service interfaces (`IngredientService`, `CuisineService`, `TagService`, `UnitService`) instead of concrete `*Impl` classes
- Switch `@Transactional` import from `jakarta.transaction` → `org.springframework.transaction.annotation`
- Add `@Transactional(readOnly = true)` to read-only methods (`list`, `get`, `search`)
- Add missing `@Override` on `save`

**`CuisineServiceIml.java`, `IngredientServiceImpl.java`, `TagServiceImpl.java`, `UnitServiceImpl.java`**
- Remove class-level `@Transactional`; annotate methods individually with `readOnly = true` for reads and `@Transactional` for writes
- Switch `@Transactional` import from `jakarta.transaction` → `org.springframework.transaction.annotation`