### PR TITLE
Adding ID filters to recipe search and paginating /list endpoint

### DIFF
--- a/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
@@ -26,9 +26,11 @@ public class RecipeController {
     private final ResponseFactory response;
 
     @GetMapping("/list")
-    public ResponseEntity<Response> getRecipes() {
+    public ResponseEntity<Response> getRecipes(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "12") int limit) {
         return response.buildResponse(OK, "Recipes retrieved",
-                recipeService.list(30));
+                recipeService.list(page, limit));
     }
 
     @PostMapping("/save")
@@ -71,9 +73,12 @@ public class RecipeController {
             @RequestParam(required = false) String name,
             @RequestParam(required = false) String tag,
             @RequestParam(required = false) String cuisine,
-            @RequestParam(required = false) String ingredient) {
+            @RequestParam(required = false) String ingredient,
+            @RequestParam(required = false) Long tagId,
+            @RequestParam(required = false) Long cuisineId,
+            @RequestParam(required = false) Long ingredientId) {
         return response.buildResponse(OK, "Recipes queried",
-                recipeService.search(new RecipeSearchParams(name, tag, cuisine, ingredient)));
+                recipeService.search(new RecipeSearchParams(name, tag, cuisine, ingredient, tagId, cuisineId, ingredientId)));
     }
 
 }

--- a/src/main/java/com/foodiesfinds/recipe_service/dto/RecipeSearchParams.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/dto/RecipeSearchParams.java
@@ -1,4 +1,5 @@
 package com.foodiesfinds.recipe_service.dto;
 
-public record RecipeSearchParams(String name, String tag, String cuisine, String ingredient) {
+public record RecipeSearchParams(String name, String tag, String cuisine, String ingredient,
+                                 Long tagId, Long cuisineId, Long ingredientId) {
 }

--- a/src/main/java/com/foodiesfinds/recipe_service/service/RecipeService.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/RecipeService.java
@@ -13,7 +13,7 @@ public interface RecipeService {
 
     RecipeResponseDTO save(RecipeSaveDTO recipeDTO);
 
-    List<NamedEntityDTO> list(int limit);
+    List<NamedEntityDTO> list(int page, int limit);
 
     RecipeResponseDTO get(Long id);
 

--- a/src/main/java/com/foodiesfinds/recipe_service/service/implementation/RecipeServiceImpl.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/service/implementation/RecipeServiceImpl.java
@@ -83,9 +83,9 @@ public class RecipeServiceImpl implements RecipeService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<NamedEntityDTO> list(int limit) {
-        log.info("Fetching the first {} recipes", limit);
-        List<Recipe> recipes = recipeRepository.findAll(PageRequest.of(0, limit)).toList();
+    public List<NamedEntityDTO> list(int page, int limit) {
+        log.info("Fetching {} recipes for page {}", limit, page);
+        List<Recipe> recipes = recipeRepository.findAll(PageRequest.of(page, limit)).toList();
         return recipes.stream()
                 .map(recipe -> new NamedEntityDTO(recipe.getId(), recipe.getName()))
                 .toList();

--- a/src/main/java/com/foodiesfinds/recipe_service/specification/RecipeSpecification.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/specification/RecipeSpecification.java
@@ -41,6 +41,27 @@ public class RecipeSpecification {
         };
     }
 
+    public static Specification<Recipe> hasCuisineId(Long cuisineId) {
+        return (root, query, cb) ->
+                cb.equal(root.join("cuisine", JoinType.INNER).get("id"), cuisineId);
+    }
+
+    public static Specification<Recipe> hasTagId(Long tagId) {
+        return (root, query, cb) -> {
+            if (query != null) query.distinct(true);
+            Join<Recipe, RecipeTag> tags = root.join("tags", JoinType.INNER);
+            return cb.equal(tags.join("tag", JoinType.INNER).get("id"), tagId);
+        };
+    }
+
+    public static Specification<Recipe> hasIngredientId(Long ingredientId) {
+        return (root, query, cb) -> {
+            if (query != null) query.distinct(true);
+            Join<Recipe, RecipeIngredient> ingredients = root.join("ingredients", JoinType.INNER);
+            return cb.equal(ingredients.join("ingredient", JoinType.INNER).get("id"), ingredientId);
+        };
+    }
+
     public static Specification<Recipe> buildFrom(RecipeSearchParams params) {
         Specification<Recipe> spec = Specification.where(null);
         if (params.name() != null && !params.name().isBlank()) {
@@ -54,6 +75,15 @@ public class RecipeSpecification {
         }
         if (params.ingredient() != null && !params.ingredient().isBlank()) {
             spec = spec.and(hasIngredientContaining(params.ingredient()));
+        }
+        if (params.tagId() != null) {
+            spec = spec.and(hasTagId(params.tagId()));
+        }
+        if (params.cuisineId() != null) {
+            spec = spec.and(hasCuisineId(params.cuisineId()));
+        }
+        if (params.ingredientId() != null) {
+            spec = spec.and(hasIngredientId(params.ingredientId()));
         }
         return spec;
     }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/RecipeControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/RecipeControllerTest.java
@@ -78,10 +78,20 @@ class RecipeControllerTest {
     }
 
     @Test
-    void getRecipes() throws Exception {
-        when(recipeService.list(30)).thenReturn(List.of(buildNamedDTO(), buildNamedDTO()));
+    void getRecipes_defaultPagination() throws Exception {
+        when(recipeService.list(0, 12)).thenReturn(List.of(buildNamedDTO(), buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/list").header("X-Api-Key", "test-api-key"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isNotEmpty());
+    }
+
+    @Test
+    void getRecipes_customPagination() throws Exception {
+        when(recipeService.list(1, 6)).thenReturn(List.of(buildNamedDTO()));
+
+        mockMvc.perform(get("/recipe/list").header("X-Api-Key", "test-api-key")
+                        .param("page", "1").param("limit", "6"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -161,7 +171,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_byName() throws Exception {
-        when(recipeService.search(new RecipeSearchParams("pasta", null, null, null)))
+        when(recipeService.search(new RecipeSearchParams("pasta", null, null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "pasta"))
@@ -171,7 +181,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_byTag() throws Exception {
-        when(recipeService.search(new RecipeSearchParams(null, "vegan", null, null)))
+        when(recipeService.search(new RecipeSearchParams(null, "vegan", null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("tag", "vegan"))
@@ -181,7 +191,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_byCuisine() throws Exception {
-        when(recipeService.search(new RecipeSearchParams(null, null, "italian", null)))
+        when(recipeService.search(new RecipeSearchParams(null, null, "italian", null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("cuisine", "italian"))
@@ -191,7 +201,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_byIngredient() throws Exception {
-        when(recipeService.search(new RecipeSearchParams(null, null, null, "flour")))
+        when(recipeService.search(new RecipeSearchParams(null, null, null, "flour", null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("ingredient", "flour"))
@@ -201,7 +211,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_multipleFilters() throws Exception {
-        when(recipeService.search(new RecipeSearchParams("pasta", "vegan", null, null)))
+        when(recipeService.search(new RecipeSearchParams("pasta", "vegan", null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "pasta").param("tag", "vegan"))
@@ -211,7 +221,7 @@ class RecipeControllerTest {
 
     @Test
     void searchRecipes_emptyResults() throws Exception {
-        when(recipeService.search(new RecipeSearchParams("xyz", null, null, null)))
+        when(recipeService.search(new RecipeSearchParams("xyz", null, null, null, null, null, null)))
                 .thenReturn(List.of());
 
         mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "xyz"))

--- a/src/test/java/com/foodiesfinds/recipe_service/service/RecipeServiceImplTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/service/RecipeServiceImplTest.java
@@ -123,7 +123,7 @@ class RecipeServiceImplTest {
         recipe.setName("Pasta");
         when(recipeRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of(recipe)));
 
-        List<NamedEntityDTO> result = recipeService.list(30);
+        List<NamedEntityDTO> result = recipeService.list(0, 30);
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(1L);
@@ -134,7 +134,7 @@ class RecipeServiceImplTest {
     void list_returnsEmpty_whenNoRecipes() {
         when(recipeRepository.findAll(any(Pageable.class))).thenReturn(new PageImpl<>(List.of()));
 
-        List<NamedEntityDTO> result = recipeService.list(30);
+        List<NamedEntityDTO> result = recipeService.list(0, 30);
 
         assertThat(result).isEmpty();
     }
@@ -190,7 +190,7 @@ class RecipeServiceImplTest {
         recipe.setName("Pasta Bolognese");
         when(recipeRepository.findAll(any(Specification.class))).thenReturn(List.of(recipe));
 
-        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("pasta", null, null, null));
+        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("pasta", null, null, null, null, null, null));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(1L);
@@ -201,7 +201,7 @@ class RecipeServiceImplTest {
     void search_returnsEmpty_whenNoMatches() {
         when(recipeRepository.findAll(any(Specification.class))).thenReturn(List.of());
 
-        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("xyz", null, null, null));
+        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("xyz", null, null, null, null, null, null));
 
         assertThat(result).isEmpty();
     }
@@ -213,7 +213,7 @@ class RecipeServiceImplTest {
         recipe.setName("Vegan Pasta");
         when(recipeRepository.findAll(any(Specification.class))).thenReturn(List.of(recipe));
 
-        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("pasta", "vegan", null, null));
+        List<NamedEntityDTO> result = recipeService.search(new RecipeSearchParams("pasta", "vegan", null, null, null, null, null));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0).getId()).isEqualTo(2L);


### PR DESCRIPTION
## Summary
- Added `tagId`, `cuisineId`, and `ingredientId` as optional query params to `GET /recipe/search` for exact ID-based filtering (complementing the existing name substring filters)
- Updated `GET /recipe/list` to accept `page` (default `0`) and `limit` (default `12`) query params, enabling a "load more" pattern — clients increment `page` on each button click to fetch the next batch of recipes

## Test plan
- [ ] `GET /recipe/search?cuisineId=1` returns only recipes with that cuisine
- [ ] `GET /recipe/search?tagId=2` returns only recipes with that tag
- [ ] `GET /recipe/search?ingredientId=3` returns only recipes containing that ingredient
- [ ] ID filters can be combined with existing name filters (e.g. `?name=pasta&cuisineId=1`)
- [ ] `GET /recipe/list` returns 12 recipes by default (page 0)
- [ ] `GET /recipe/list?page=1&limit=6` returns the next 6 recipes
- [ ] All 70 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)