### PR TITLE
Rename endpoints to RESTful noun-based paths

### DIFF
--- a/src/main/java/com/foodiesfinds/recipe_service/controller/CuisineController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/CuisineController.java
@@ -13,20 +13,18 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/cuisine")
+@RequestMapping("/cuisines")
 @RequiredArgsConstructor
 public class CuisineController {
 
     private final CuisineService cuisineService;
     private final ResponseFactory response;
 
-    @GetMapping("/list")
-    public ResponseEntity<Response> getCuisines() {
-        return response.buildResponse(OK, "Cuisines retrieved", cuisineService.list());
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<Response> searchCuisines(@RequestParam("query") String query) {
+    @GetMapping
+    public ResponseEntity<Response> getCuisines(@RequestParam(required = false) String query) {
+        if (query == null || query.isBlank()) {
+            return response.buildResponse(OK, "Cuisines retrieved", cuisineService.list());
+        }
         return response.buildResponse(OK, "Cuisines queried", cuisineService.search(query));
     }
 

--- a/src/main/java/com/foodiesfinds/recipe_service/controller/ImageController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/ImageController.java
@@ -16,7 +16,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/recipe/image")
+@RequestMapping("/recipes/images")
 @RequiredArgsConstructor
 public class ImageController {
 

--- a/src/main/java/com/foodiesfinds/recipe_service/controller/IngredientController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/IngredientController.java
@@ -13,20 +13,18 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/ingredient")
+@RequestMapping("/ingredients")
 @RequiredArgsConstructor
 public class IngredientController {
 
     private final IngredientService ingredientService;
     private final ResponseFactory response;
 
-    @GetMapping("/list")
-    public ResponseEntity<Response> getIngredients() {
-        return response.buildResponse(OK, "Ingredients retrieved", ingredientService.list());
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<Response> searchIngredients(@RequestParam("query") String query) {
+    @GetMapping
+    public ResponseEntity<Response> getIngredients(@RequestParam(required = false) String query) {
+        if (query == null || query.isBlank()) {
+            return response.buildResponse(OK, "Ingredients retrieved", ingredientService.list());
+        }
         return response.buildResponse(OK, "Ingredients queried", ingredientService.search(query));
     }
 

--- a/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/RecipeController.java
@@ -20,7 +20,7 @@ import static org.springframework.http.HttpStatus.OK;
 
 
 @RestController
-@RequestMapping("/recipe")
+@RequestMapping("/recipes")
 @RequiredArgsConstructor
 public class RecipeController {
 
@@ -28,15 +28,27 @@ public class RecipeController {
 
     private final ResponseFactory response;
 
-    @GetMapping("/list")
+    @GetMapping
     public ResponseEntity<Response> getRecipes(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "12") int limit) {
-        return response.buildResponse(OK, "Recipes retrieved",
-                recipeService.list(page, limit));
+            @RequestParam(defaultValue = "12") int limit,
+            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String tag,
+            @RequestParam(required = false) String cuisine,
+            @RequestParam(required = false) String ingredient,
+            @RequestParam(required = false) Long tagId,
+            @RequestParam(required = false) Long cuisineId,
+            @RequestParam(required = false) Long ingredientId) {
+        if (name == null && tag == null && cuisine == null && ingredient == null
+                && tagId == null && cuisineId == null && ingredientId == null) {
+            return response.buildResponse(OK, "Recipes retrieved",
+                    recipeService.list(page, limit));
+        }
+        return response.buildResponse(OK, "Recipes queried",
+                recipeService.search(new RecipeSearchParams(name, tag, cuisine, ingredient, tagId, cuisineId, ingredientId)));
     }
 
-    @PostMapping("/save")
+    @PostMapping
     public ResponseEntity<Response> saveRecipe(@RequestBody @Valid RecipeSaveDTO recipe) {
 
         RecipeResponseDTO savedRecipe = recipeService.save(recipe);
@@ -50,36 +62,23 @@ public class RecipeController {
         return response.buildResponse(CREATED, "Recipe saved", savedRecipe, location);
     }
 
-    @GetMapping("/get/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<Response> getRecipe(@PathVariable("id") Long id) {
         return response.buildResponse(OK, "Recipe retrieved",
                 recipeService.get(id));
     }
 
-    @PatchMapping("/update/{id}")
+    @PatchMapping("/{id}")
     public ResponseEntity<Response> updateRecipe(@RequestBody @Valid RecipeUpdateDTO recipe,
                                                  @PathVariable("id") Long id) {
         return response.buildResponse(OK, "Recipe updated",
                 recipeService.update(recipe, id));
     }
 
-    @DeleteMapping("/delete/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteRecipe(@PathVariable("id") Long id) {
         recipeService.delete(id);
         return ResponseEntity.noContent().build();
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<Response> searchRecipes(
-            @RequestParam(required = false) String name,
-            @RequestParam(required = false) String tag,
-            @RequestParam(required = false) String cuisine,
-            @RequestParam(required = false) String ingredient,
-            @RequestParam(required = false) Long tagId,
-            @RequestParam(required = false) Long cuisineId,
-            @RequestParam(required = false) Long ingredientId) {
-        return response.buildResponse(OK, "Recipes queried",
-                recipeService.search(new RecipeSearchParams(name, tag, cuisine, ingredient, tagId, cuisineId, ingredientId)));
     }
 
 }

--- a/src/main/java/com/foodiesfinds/recipe_service/controller/TagController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/TagController.java
@@ -13,20 +13,18 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/tag")
+@RequestMapping("/tags")
 @RequiredArgsConstructor
 public class TagController {
 
     private final TagService tagService;
     private final ResponseFactory response;
 
-    @GetMapping("/list")
-    public ResponseEntity<Response> getTags() {
-        return response.buildResponse(OK, "Tags retrieved", tagService.list());
-    }
-
-    @GetMapping("/search")
-    public ResponseEntity<Response> searchTags(@RequestParam("query") String query) {
+    @GetMapping
+    public ResponseEntity<Response> getTags(@RequestParam(required = false) String query) {
+        if (query == null || query.isBlank()) {
+            return response.buildResponse(OK, "Tags retrieved", tagService.list());
+        }
         return response.buildResponse(OK, "Tags queried", tagService.search(query));
     }
 

--- a/src/main/java/com/foodiesfinds/recipe_service/controller/UnitController.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/controller/UnitController.java
@@ -12,14 +12,14 @@ import org.springframework.web.bind.annotation.RestController;
 import static org.springframework.http.HttpStatus.OK;
 
 @RestController
-@RequestMapping("/unit")
+@RequestMapping("/units")
 @RequiredArgsConstructor
 public class UnitController {
 
     private final UnitService unitService;
     private final ResponseFactory response;
 
-    @GetMapping("/list")
+    @GetMapping
     public ResponseEntity<Response> getUnits() {
         return response.buildResponse(OK, "Units retrieved", unitService.list());
     }

--- a/src/main/java/com/foodiesfinds/recipe_service/core/filter/ApiKeyFilter.java
+++ b/src/main/java/com/foodiesfinds/recipe_service/core/filter/ApiKeyFilter.java
@@ -29,7 +29,7 @@ public class ApiKeyFilter extends OncePerRequestFilter {
                                     FilterChain filterChain) throws ServletException, IOException {
         String apiKey = request.getHeader("X-Api-Key");
         boolean isAdminEndpoint = request.getMethod().equalsIgnoreCase("DELETE")
-                && request.getRequestURI().startsWith("/recipe/delete/");
+                && request.getRequestURI().matches("/recipes/\\d+");
 
         if (apiKey != null) {
             String adminKey = apiKeyProperties.getKeys().get("admin");

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/CuisineControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/CuisineControllerTest.java
@@ -45,7 +45,7 @@ class CuisineControllerTest {
     void getCuisines() throws Exception {
         when(cuisineService.list()).thenReturn(List.of(buildCuisineDTO()));
 
-        mockMvc.perform(get("/cuisine/list").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/cuisines").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -54,7 +54,7 @@ class CuisineControllerTest {
     void searchCuisines() throws Exception {
         when(cuisineService.search("ital")).thenReturn(List.of(new NamedEntityDTO(1L, "Italian")));
 
-        mockMvc.perform(get("/cuisine/search").header("X-Api-Key", "test-api-key").param("query", "ital"))
+        mockMvc.perform(get("/cuisines").header("X-Api-Key", "test-api-key").param("query", "ital"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -63,13 +63,13 @@ class CuisineControllerTest {
     void searchCuisines_emptyResults() throws Exception {
         when(cuisineService.search("xyz")).thenReturn(List.of());
 
-        mockMvc.perform(get("/cuisine/search").header("X-Api-Key", "test-api-key").param("query", "xyz"))
+        mockMvc.perform(get("/cuisines").header("X-Api-Key", "test-api-key").param("query", "xyz"))
                 .andExpect(status().isOk());
     }
 
     @Test
     void missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/cuisine/list"))
+        mockMvc.perform(get("/cuisines"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/ImageControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/ImageControllerTest.java
@@ -46,7 +46,7 @@ class ImageControllerTest {
                 "file", "test.jpg", "image/jpeg", "fake-image-bytes".getBytes()
         );
 
-        mockMvc.perform(multipart("/recipe/image")
+        mockMvc.perform(multipart("/recipes/images")
                         .file(file)
                         .header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
@@ -61,7 +61,7 @@ class ImageControllerTest {
                 "file", "empty.jpg", "image/jpeg", new byte[0]
         );
 
-        mockMvc.perform(multipart("/recipe/image")
+        mockMvc.perform(multipart("/recipes/images")
                         .file(file)
                         .header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isBadRequest());
@@ -75,7 +75,7 @@ class ImageControllerTest {
                 "file", "document.pdf", "application/pdf", "pdf-bytes".getBytes()
         );
 
-        mockMvc.perform(multipart("/recipe/image")
+        mockMvc.perform(multipart("/recipes/images")
                         .file(file)
                         .header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isBadRequest());
@@ -87,7 +87,7 @@ class ImageControllerTest {
                 "file", "test.jpg", "image/jpeg", "fake-image-bytes".getBytes()
         );
 
-        mockMvc.perform(multipart("/recipe/image")
+        mockMvc.perform(multipart("/recipes/images")
                         .file(file))
                 .andExpect(status().isUnauthorized());
     }
@@ -96,7 +96,7 @@ class ImageControllerTest {
     void deleteImage_success() throws Exception {
         doNothing().when(imageService).delete(any());
 
-        mockMvc.perform(delete("/recipe/image")
+        mockMvc.perform(delete("/recipes/images")
                         .param("key", "recipes/some-uuid.jpg")
                         .header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isNoContent());
@@ -106,7 +106,7 @@ class ImageControllerTest {
     void deleteImage_invalidKey_returnsBadRequest() throws Exception {
         doThrow(new BadRequestException("Invalid image key")).when(imageService).delete(any());
 
-        mockMvc.perform(delete("/recipe/image")
+        mockMvc.perform(delete("/recipes/images")
                         .param("key", "other/some-file.jpg")
                         .header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isBadRequest());
@@ -114,7 +114,7 @@ class ImageControllerTest {
 
     @Test
     void deleteImage_missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(delete("/recipe/image")
+        mockMvc.perform(delete("/recipes/images")
                         .param("key", "recipes/some-uuid.jpg"))
                 .andExpect(status().isUnauthorized());
     }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/IngredientControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/IngredientControllerTest.java
@@ -45,7 +45,7 @@ class IngredientControllerTest {
     void getIngredients() throws Exception {
         when(ingredientService.list()).thenReturn(List.of(buildIngredientDTO()));
 
-        mockMvc.perform(get("/ingredient/list").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/ingredients").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -54,7 +54,7 @@ class IngredientControllerTest {
     void searchIngredients() throws Exception {
         when(ingredientService.search("flo")).thenReturn(List.of(new NamedEntityDTO(1L, "flour")));
 
-        mockMvc.perform(get("/ingredient/search").header("X-Api-Key", "test-api-key").param("query", "flo"))
+        mockMvc.perform(get("/ingredients").header("X-Api-Key", "test-api-key").param("query", "flo"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -63,13 +63,13 @@ class IngredientControllerTest {
     void searchIngredients_emptyResults() throws Exception {
         when(ingredientService.search("xyz")).thenReturn(List.of());
 
-        mockMvc.perform(get("/ingredient/search").header("X-Api-Key", "test-api-key").param("query", "xyz"))
+        mockMvc.perform(get("/ingredients").header("X-Api-Key", "test-api-key").param("query", "xyz"))
                 .andExpect(status().isOk());
     }
 
     @Test
     void missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/ingredient/list"))
+        mockMvc.perform(get("/ingredients"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/RecipeControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/RecipeControllerTest.java
@@ -85,7 +85,7 @@ class RecipeControllerTest {
     void getRecipes_defaultPagination() throws Exception {
         when(recipeService.list(0, 12)).thenReturn(List.of(buildNamedDTO(), buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/list").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -94,7 +94,7 @@ class RecipeControllerTest {
     void getRecipes_customPagination() throws Exception {
         when(recipeService.list(1, 6)).thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/list").header("X-Api-Key", "test-api-key")
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key")
                         .param("page", "1").param("limit", "6"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
@@ -104,7 +104,7 @@ class RecipeControllerTest {
     void saveRecipe() throws Exception {
         when(recipeService.save(any())).thenReturn(buildResponseDTO());
 
-        mockMvc.perform(post("/recipe/save")
+        mockMvc.perform(post("/recipes")
                         .header("X-Api-Key", "test-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(buildValidSaveDTO())))
@@ -116,7 +116,7 @@ class RecipeControllerTest {
 
     @Test
     void saveRecipe_validationFailure() throws Exception {
-        mockMvc.perform(post("/recipe/save")
+        mockMvc.perform(post("/recipes")
                         .header("X-Api-Key", "test-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{}"))
@@ -127,7 +127,7 @@ class RecipeControllerTest {
     void getRecipe() throws Exception {
         when(recipeService.get(1L)).thenReturn(buildResponseDTO());
 
-        mockMvc.perform(get("/recipe/get/1").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/recipes/1").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.message").value("Recipe retrieved"));
     }
@@ -136,7 +136,7 @@ class RecipeControllerTest {
     void getRecipe_notFound() throws Exception {
         when(recipeService.get(99L)).thenThrow(new NotFoundException("Recipe not found"));
 
-        mockMvc.perform(get("/recipe/get/99").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/recipes/99").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isNotFound());
     }
 
@@ -144,7 +144,7 @@ class RecipeControllerTest {
     void updateRecipe() throws Exception {
         when(recipeService.update(any(), eq(1L))).thenReturn(buildResponseDTO());
 
-        mockMvc.perform(patch("/recipe/update/1")
+        mockMvc.perform(patch("/recipes/1")
                         .header("X-Api-Key", "test-api-key")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new RecipeUpdateDTO())))
@@ -156,7 +156,7 @@ class RecipeControllerTest {
     void deleteRecipe() throws Exception {
         doNothing().when(recipeService).delete(1L);
 
-        mockMvc.perform(delete("/recipe/delete/1").header("X-Api-Key", "test-admin-key"))
+        mockMvc.perform(delete("/recipes/1").header("X-Api-Key", "test-admin-key"))
                 .andExpect(status().isNoContent());
     }
 
@@ -164,13 +164,13 @@ class RecipeControllerTest {
     void deleteRecipe_notFound() throws Exception {
         doThrow(new NotFoundException("Recipe not found")).when(recipeService).delete(99L);
 
-        mockMvc.perform(delete("/recipe/delete/99").header("X-Api-Key", "test-admin-key"))
+        mockMvc.perform(delete("/recipes/99").header("X-Api-Key", "test-admin-key"))
                 .andExpect(status().isNotFound());
     }
 
     @Test
     void deleteRecipe_userKeyRejected() throws Exception {
-        mockMvc.perform(delete("/recipe/delete/1").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(delete("/recipes/1").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -179,7 +179,7 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams("pasta", null, null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "pasta"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("name", "pasta"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -189,7 +189,7 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams(null, "vegan", null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("tag", "vegan"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("tag", "vegan"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -199,7 +199,7 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams(null, null, "italian", null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("cuisine", "italian"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("cuisine", "italian"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -209,7 +209,7 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams(null, null, null, "flour", null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("ingredient", "flour"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("ingredient", "flour"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -219,7 +219,7 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams("pasta", "vegan", null, null, null, null, null)))
                 .thenReturn(List.of(buildNamedDTO()));
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "pasta").param("tag", "vegan"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("name", "pasta").param("tag", "vegan"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -229,13 +229,13 @@ class RecipeControllerTest {
         when(recipeService.search(new RecipeSearchParams("xyz", null, null, null, null, null, null)))
                 .thenReturn(List.of());
 
-        mockMvc.perform(get("/recipe/search").header("X-Api-Key", "test-api-key").param("name", "xyz"))
+        mockMvc.perform(get("/recipes").header("X-Api-Key", "test-api-key").param("name", "xyz"))
                 .andExpect(status().isOk());
     }
 
     @Test
     void missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/recipe/list"))
+        mockMvc.perform(get("/recipes"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/TagControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/TagControllerTest.java
@@ -45,7 +45,7 @@ class TagControllerTest {
     void getTags() throws Exception {
         when(tagService.list()).thenReturn(List.of(buildTagDTO()));
 
-        mockMvc.perform(get("/tag/list").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/tags").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -54,7 +54,7 @@ class TagControllerTest {
     void searchTags() throws Exception {
         when(tagService.search("veg")).thenReturn(List.of(new NamedEntityDTO(1L, "vegan")));
 
-        mockMvc.perform(get("/tag/search").header("X-Api-Key", "test-api-key").param("query", "veg"))
+        mockMvc.perform(get("/tags").header("X-Api-Key", "test-api-key").param("query", "veg"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
@@ -63,13 +63,13 @@ class TagControllerTest {
     void searchTags_emptyResults() throws Exception {
         when(tagService.search("xyz")).thenReturn(List.of());
 
-        mockMvc.perform(get("/tag/search").header("X-Api-Key", "test-api-key").param("query", "xyz"))
+        mockMvc.perform(get("/tags").header("X-Api-Key", "test-api-key").param("query", "xyz"))
                 .andExpect(status().isOk());
     }
 
     @Test
     void missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/tag/list"))
+        mockMvc.perform(get("/tags"))
                 .andExpect(status().isUnauthorized());
     }
 }

--- a/src/test/java/com/foodiesfinds/recipe_service/controller/UnitControllerTest.java
+++ b/src/test/java/com/foodiesfinds/recipe_service/controller/UnitControllerTest.java
@@ -37,14 +37,14 @@ class UnitControllerTest {
     void getUnits() throws Exception {
         when(unitService.list()).thenReturn(List.of(new UnitResponseDTO(1L, "cup", "c")));
 
-        mockMvc.perform(get("/unit/list").header("X-Api-Key", "test-api-key"))
+        mockMvc.perform(get("/units").header("X-Api-Key", "test-api-key"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").isNotEmpty());
     }
 
     @Test
     void missingApiKey_returnsUnauthorized() throws Exception {
-        mockMvc.perform(get("/unit/list"))
+        mockMvc.perform(get("/units"))
                 .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Summary

- Pluralize all base paths (`/recipe` → `/recipes`, `/cuisine` → `/cuisines`, `/tag` → `/tags`, `/ingredient` → `/ingredients`, `/unit` → `/units`, `/recipe/image` → `/recipes/images`)
- Remove verb segments from URLs (`/save`, `/get/{id}`, `/update/{id}`, `/delete/{id}`) — HTTP methods now express the action
- Merge separate `list` and `search` endpoints into a single `GET /collection` endpoint with optional query params (e.g. `GET /recipes?name=pasta`, `GET /cuisines?query=thai`)
- Update `ApiKeyFilter` admin-endpoint check to match new `DELETE /recipes/{id}` pattern
- Update all controller tests to use new URL paths

## Test plan

- [x] All 88 tests pass with updated URLs
- [x] Confirm old paths return 404 (e.g. `GET /recipe/list`, `POST /recipe/save`)
- [x] Smoke test merged endpoints: `GET /recipes?name=pasta`, `GET /cuisines?query=thai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)